### PR TITLE
Modern ubuntu fix

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://loms.voria.org
 Package: samsung-tools
 Architecture: all
 Suggests: phc-intel
-Depends: pm-utils, python-gtk2, xbindkeys, rfkill, vbetool
+Depends: pm-utils, python-gtk2, xbindkeys, rfkill, vbetool, python-dbus
 Description: Tools for Samsung laptops.
  'Samsung Tools' is the successor of 'Samsung Scripts' provided by the
  'Linux On My Samsung' project.

--- a/debian/rules
+++ b/debian/rules
@@ -28,7 +28,7 @@ install:
 	dh_prep
 	dh_installchangelogs
 	dh_installdocs
-	dh_installinit --no-start --upstart-only
+	dh_installinit --no-start
 	dh_installdeb
 	$(MAKE) DESTDIR=$(CURDIR)/debian/samsung-tools install
 


### PR DESCRIPTION
Hi!

For Ubuntu 16.04 and above the python-dbus dependency should be specified. It is not installed by default anymore.

Also systemd replaces upstart in all supported Ubuntu versions.